### PR TITLE
For dylan/console cleanup

### DIFF
--- a/recipes-images/gumstix/gumstix-console-image.bb
+++ b/recipes-images/gumstix/gumstix-console-image.bb
@@ -37,7 +37,6 @@ TOOLS_INSTALL = " \
   media-ctl \
   yavta \
   v4l-utils \
-  mplayer2 \
   mtd-utils-ubifs \
 "
 

--- a/recipes-images/gumstix/gumstix-console-image.bb
+++ b/recipes-images/gumstix/gumstix-console-image.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "A basic console image for Gumstix boards."
 LICENSE = "MIT"
 PR = "r0"
 
-IMAGE_FEATURES += "splash package-management ssh-server-openssh tools-sdk"
+IMAGE_FEATURES += "splash package-management ssh-server-openssh"
 IMAGE_LINGUAS = "en-us"
 
 inherit core-image
@@ -38,6 +38,10 @@ TOOLS_INSTALL = " \
   yavta \
   v4l-utils \
   mtd-utils-ubifs \
+  coreutils \
+  diffutils \
+  findutils \
+  less \
 "
 
 IMAGE_INSTALL += " \


### PR DESCRIPTION
This removes some stuff that doesn't really belong in a standard console image.  IMO there's still too much here; might be good to create a gumstix-test-image that extends gumstix-console-image with whatever packages are necessary to validate that the board features (camera, audio, whatever) are operating.
