### PR TITLE
local.conf.sample: Disable wic

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -285,7 +285,7 @@ DISTRO_FEATURES_append = " bluez5"
 INSANE_SKIP_python-wstool = "installed-vs-shipped"
 
 # Use wic to generate 2G SD-card image for overo
-IMAGE_FSTYPES_append_overo = " wic"
-WKS_FILE_overo = "sdimage-gumstix.wks"
-IMAGE_BOOT_FILES_overo ?= "MLO u-boot.img uImage"
+#IMAGE_FSTYPES_append_overo = " wic"
+#WKS_FILE_overo = "sdimage-gumstix.wks"
+#IMAGE_BOOT_FILES_overo ?= "MLO u-boot.img uImage"
 


### PR DESCRIPTION
wic needs latest OE-core and dev is still on fido
until the dev moves to use morty or newer this
should be kept disabled fixes image build errors with fido

ERROR: No IMAGE_CMD defined for IMAGE_FSTYPES entry 'wic' - possibly invalid type name or missing support class

Signed-off-by: Khem Raj raj.khem@gmail.com
