### PR TITLE
diagnostic-aggregator: improve build dependency

### DIFF
--- a/recipes-ros/diagnostics/diagnostic-aggregator_1.8.10.bbappend
+++ b/recipes-ros/diagnostics/diagnostic-aggregator_1.8.10.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "bondcpp bondpy"


### PR DESCRIPTION
bitbake diagnostic-aggregrator failed due to missing build dependencies.

Signed-off-by: Jerry Hung <jerry@gumstix.com>