### PR TITLE
Raspberry Pi fixes for Yocto-Thud

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -355,8 +355,8 @@ INSANE_SKIP_python-wstool = "installed-vs-shipped"
 
 # AutoBSP
 RPI_EXTRA_CONFIG = '# Gumstix Config Extras\n'
-RPI_EXTRA_CONFIG_append_raspberrypi-cm3 += '\n#For Raspberry Pi Compute Module:\ndtoverlay=devicetree-rpi_cm\n'
-RPI_EXTRA_CONFIG_append_raspberrypi3 += '\n#For Pi HAT connector:\n#dtoverlay=devicetree-rpi_hat\n'
+RPI_EXTRA_CONFIG_append_raspberrypi-cm3 += '\n#AutoBSP For Raspberry Pi Compute Module:\ndtoverlay=devicetree-rpi_cm\n'
+RPI_EXTRA_CONFIG_append_raspberrypi3 += '\n#AutoBSP For Pi HAT connector:\ndtoverlay=devicetree-rpi_hat\n'
 RPI_EXTRA_CONFIG_append_raspberrypi-cm3 += '\n# Enable Camera support for OV5640\n# dtparam=i2c0=on\n# dtoverlay=ov5640-gumstix'
 
 # Raspberry Pi Userland, for Enable/Disable camera addon support

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -354,13 +354,15 @@ INSANE_SKIP_python-wstool = "installed-vs-shipped"
 #IMAGE_BOOT_FILES_overo ?= "MLO u-boot.img uImage"
 
 # AutoBSP
-RPI_EXTRA_CONFIG = "\n#For Raspberry Pi Compute Module:\n#dtoverlay=devicetree-rpi_cm\n"
-RPI_EXTRA_CONFIG += "\n#For Pi HAT connector:\n#dtoverlay=devicetree-rpi_hat\n"
+RPI_EXTRA_CONFIG = '# Gumstix Config Extras\n'
+RPI_EXTRA_CONFIG_append_raspberrypi-cm3 += '\n#For Raspberry Pi Compute Module:\ndtoverlay=devicetree-rpi_cm\n'
+RPI_EXTRA_CONFIG_append_raspberrypi3 += '\n#For Pi HAT connector:\n#dtoverlay=devicetree-rpi_hat\n'
+RPI_EXTRA_CONFIG_append_raspberrypi-cm3 += '\n# Enable Camera support for OV5640\n# dtparam=i2c0=on\n# dtoverlay=ov5640-gumstix'
 
 # Raspberry Pi Userland, for Enable/Disable camera addon support
 # Feel free to comment it out, if you're not using cameras
-RPI_EXTRA_CONFIG += "\nstart_x=1"
-RPI_EXTRA_CONFIG += "\ngpu_mem=128\n"
+RPI_EXTRA_CONFIG += '\nstart_x=1'
+RPI_EXTRA_CONFIG += '\ngpu_mem=128\n'
 ENABLE_KGDB_raspberrypi-cm3 = "0"
 
 # Mask out toradex layers when not building imx devices


### PR DESCRIPTION
* Depends on removal of rpi-config_git.bbappend from gumstix/meta-gumstix
* Adds uncommented `dtoverlay=devicetree-x` line, where **x** is either `rpi_hat` or `rpi_cm` based on $MACHINE
* Makes quotation marks consistent for all RPI_EXTRA_CONFIG lines